### PR TITLE
pre-allocate freq to same size as ts

### DIFF
--- a/trigram.go
+++ b/trigram.go
@@ -197,7 +197,7 @@ func (idx Index) QueryTrigrams(ts []T) []DocID {
 		return idx[tAllDocIDs]
 	}
 
-	var freq []int
+	freq := make([]int, 0, len(ts))
 
 	for _, t := range ts {
 		d, ok := idx[t]


### PR DESCRIPTION
whether this is useful probably depends on
how often the loop below returns early.

If it's common to call this function with non-existant
trigrams, forget about this.

also we should solve #9 first, probably