### PR TITLE
remove unneeded clause

### DIFF
--- a/trigram.go
+++ b/trigram.go
@@ -265,7 +265,7 @@ scan:
 			}
 		}
 
-		for bidx < len(b) && a[aidx] > b[bidx] {
+		for a[aidx] > b[bidx] {
 			bidx++
 			if bidx >= len(b) {
 				break scan


### PR DESCRIPTION
* this makes the clause symmetrical with the mirror case above
* it was not needed to begin with since we break out before it can
  trigger